### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: ["main", "develop"]


### PR DESCRIPTION
Potential fix for [https://github.com/kramqx/doxynix/security/code-scanning/1](https://github.com/kramqx/doxynix/security/code-scanning/1)

In general, the fix is to explicitly declare a `permissions` block that restricts the GitHub Actions `GITHUB_TOKEN` to the minimal necessary scope, instead of relying on default repository/organization permissions. This block can be added at the workflow root (applies to all jobs) or at the job level (applies only to that job).

For this specific workflow, none of the steps need to push commits, modify PRs, or write to other GitHub resources. The safest least-privilege setting is to add `permissions: contents: read`. The CodeQL suggestion also mentions `contents: read` as a minimal starting point. To avoid changing existing functionality, we will add the `permissions` key at the top workflow level, just under `name: CI` and before `on:`, so that all current and future jobs inherit this restricted permission set. No existing steps, actions, or environment variables need to be changed; we simply introduce the explicit permissions block.

Concretely:
- Edit `.github/workflows/ci.yml`.
- Insert:
  ```yaml
  permissions:
    contents: read
  ```
  after line 1 (`name: CI`).
- No imports or additional files are necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
