### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,8 @@ jobs:
   sonarqube:
     name: SonarQube
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Potential fix for [https://github.com/doxynix/doxynix/security/code-scanning/2](https://github.com/doxynix/doxynix/security/code-scanning/2)

In general, the fix is to explicitly define a `permissions:` block for the workflow and/or individual jobs so that the `GITHUB_TOKEN` used by this workflow has only the minimum privileges required (typically `contents: read` for analysis jobs, and optionally additional, more specific write scopes if genuinely needed).

For this specific workflow, the safest change without altering existing functionality is to add a `permissions: contents: read` block. Since we only see a single `sonarqube` job and there is no evidence that it needs to write to the repository or manage other resources via `GITHUB_TOKEN`, we can give it read-only access to repository contents. To keep the change minimal and clearly associated with the highlighted job, we will add the `permissions` block at the job level under `sonarqube:` (indented correctly under that job). No extra imports or tools are needed; this is purely a YAML configuration change within `.github/workflows/build.yml`.

Concretely, in `.github/workflows/build.yml`, under `jobs: sonarqube: name: SonarQube`, insert:

```yaml
    permissions:
      contents: read
```

This ensures the `sonarqube` job’s `GITHUB_TOKEN` is limited to read-only repository content access, satisfying the CodeQL recommendation and adhering to the principle of least privilege.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
