### PR TITLE
Potential fix for code scanning alert no. 5: Incomplete URL substring sanitization

### DIFF
--- a/src/features/repo/ui/CreateRepoDialog.tsx
+++ b/src/features/repo/ui/CreateRepoDialog.tsx
@@ -31,16 +31,12 @@ function isGitHubUrl(input: string): boolean {
     return false;
   }
 
-  // If the user enters something like "owner/repo", treat it as a GitHub URL-like input.
   if (!/^https?:\/\//i.test(trimmed) && trimmed.includes("/")) {
     try {
       const normalized = `https://github.com/${trimmed.replace(/^\/+/, "")}`;
       const parsed = new URL(normalized);
       const hostname = parsed.hostname.toLowerCase();
-      return (
-        hostname === "github.com" ||
-        hostname.endsWith(".github.com")
-      );
+      return hostname === "github.com" || hostname.endsWith(".github.com");
     } catch {
       return false;
     }


### PR DESCRIPTION
Potential fix for [https://github.com/doxynix/doxynix/security/code-scanning/5](https://github.com/doxynix/doxynix/security/code-scanning/5)

In general, the fix is to stop treating the URL as a raw string for host checks and instead parse it with the built‑in `URL` class, then compare the parsed hostname (or origin) against an explicit rule. For this case, we only use `isUrl` as a heuristic, so we can still treat non‑parsable values as “not a URL”, and when parsing succeeds, check that the hostname is exactly `github.com` or an allowed subdomain of it.

Concrete best fix for this file:

- Replace `const isUrl = url.includes("github.com") || url.includes("/");` with a small helper that:
  - Attempts to construct `new URL(urlTrimmed)` (after trimming whitespace).
  - On failure, returns `false`.
  - On success, checks `parsed.hostname` against `github.com` or `*.github.com`.
- Keep the `/` heuristic if desired (e.g., treat strings with a slash as URL-like even without a scheme) but do it in a safer way by first normalizing inputs like `owner/repo` via a prefixed `https://github.com/` before parsing.
- Implement this helper inside the same component file (no new dependencies required), placed above `CreateRepoDialog` to avoid changing imports.

This preserves all existing functionality (distinguishing “URL-ish github input” from plain text search) while ensuring `"github.com"` is not treated as a free‑floating substring anywhere in the string.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
